### PR TITLE
Fully localize "Contents" heading for language guide pages.

### DIFF
--- a/src/languages/cy.json
+++ b/src/languages/cy.json
@@ -7,6 +7,7 @@
   "Back": "Yn ôl",
   "Categories": "Categorïau",
   "Close": "Cau",
+  "Contents": "Cynnwys",
   "English": "Saesneg",
   "Filters": "Hidlyddion",
   "Follow us": "Dilynwch ni",

--- a/src/templates/guide.html
+++ b/src/templates/guide.html
@@ -58,7 +58,7 @@
                         {{-
                             onsTableOfContents({
                                 "ariaLabel": global.strings.tocLabel,
-                                "title": global.strings.tocTitle,
+                                "title": "Contents"|localize,
                                 "itemsList": sectionNav,
                                 "skipLink": {
                                     "url": "#section-content",


### PR DESCRIPTION
Previously the "Contents" heading was localized for the 3 sites (EN/CY/NI) but not it is localized for those + arbitrary language guide pages.