### PR TITLE
Lang attribute language pages

### DIFF
--- a/src/graphql/dataQuery.gql
+++ b/src/graphql/dataQuery.gql
@@ -114,6 +114,7 @@ query Data($site: [String]) {
       templateTextOverrides__pull__: templateTextOverrides { _entryRef: id }
       seo { ...seo_Ether_SeoData_Fragment }
       rtl
+      languageCode
     }
     ...on contentPage_question_Entry {
       navigationTitle

--- a/src/templates/guide.html
+++ b/src/templates/guide.html
@@ -29,7 +29,7 @@
             {% endfor %}
         {% endif %}
 
-        <div class="grid u-mt-s" {% if entry.languageCode and entry.languageCode !== "site" %}lang="{{ entry.languageCode }}" {% endif%}>
+        <div class="grid u-mt-s" {% if entry.languageCode %}lang="{{ entry.languageCode }}" {% endif %}>
             <div class="grid__col col-7@m">
                 <main id="main-content" role="main" class="page__main u-mt-no">
                     <h1 class="u-mb-l">

--- a/src/templates/guide.html
+++ b/src/templates/guide.html
@@ -29,7 +29,7 @@
             {% endfor %}
         {% endif %}
 
-        <div class="grid u-mt-s">
+        <div class="grid u-mt-s" {% if entry.languageCode and entry.languageCode !== "site" %}lang="{{ entry.languageCode }}" {% endif%}>
             <div class="grid__col col-7@m">
                 <main id="main-content" role="main" class="page__main u-mt-no">
                     <h1 class="u-mb-l">

--- a/src/templates/languagesSupport.html
+++ b/src/templates/languagesSupport.html
@@ -53,9 +53,20 @@
                                 <div class="grid__col col-4@m">
                                     {% set itemsList = [] %}
                                     {% for item in column.supportEntries %}
+                                        {% set languagePageTitle = item.navigationTitle %}
+
+                                        {% if r/\(([^\)]+)\)/.test(item.navigationTitle) %}
+                                            {% set languagePageTitle_sitePart = item.navigationTitle.match( r/\(([^\)]+)\)/ )[1] %}
+                                            {% set languagePageTitle_nativePart = item.navigationTitle.match( r/^[^\(]+/ )[0].trim() %}
+                                            {% if item.languageCode %}
+                                                {% set languagePageTitle_nativePart = '<span lang="' + item.languageCode + '">' + languagePageTitle_nativePart + '</span>' %}
+                                            {% endif %}
+                                            {% set languagePageTitle = languagePageTitle_nativePart + " (" + languagePageTitle_sitePart + ")" %}
+                                        {% endif %}
+
                                         {% set itemsList = (itemsList.push({
                                             "url": item.url,
-                                            "text": item.navigationTitle
+                                            "text": languagePageTitle
                                         }), itemsList) %}
                                     {% endfor %}
 
@@ -83,7 +94,12 @@
                                     {% set languagePageTitle = item.navigationTitle %}
 
                                     {% if r/\(([^\)]+)\)/.test(item.navigationTitle) %}
-                                        {% set languagePageTitle = item.navigationTitle.match( r/\(([^\)]+)\)/ )[1] + " (" + item.navigationTitle.match( r/^[^\(]+/ )[0].trim() + ")" %}
+                                        {% set languagePageTitle_sitePart = item.navigationTitle.match( r/\(([^\)]+)\)/ )[1] %}
+                                        {% set languagePageTitle_nativePart = item.navigationTitle.match( r/^[^\(]+/ )[0].trim() %}
+                                        {% if item.languageCode %}
+                                            {% set languagePageTitle_nativePart = '<span lang="' + item.languageCode + '">' + languagePageTitle_nativePart + '</span>' %}
+                                        {% endif %}
+                                        {% set languagePageTitle = languagePageTitle_sitePart + " (" + languagePageTitle_nativePart + ")" %}
                                     {% endif %}
 
                                     {% set itemsList = (itemsList.push({


### PR DESCRIPTION
Adds `lang="xyz"` attribute to the native language text of the special language guide pages and links to those from the language support template.

Things to look out for:
- Normal EN/NI/CY guide pages are unaffected.
- The special language guide pages (root and child pages) are affected as expected.
- Links from language support page have "span" with lang attribute as expected for EN/NI/CY variations.